### PR TITLE
Drop support for Ruby 3.1 and fix dependencies for newer Ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['3.1', '3.2', '3.3'] }
+      matrix: { ruby: [3.2', '3.3', '3.4'] }
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: [3.2', '3.3', '3.4'] }
+      matrix: { ruby: ['3.2', '3.3', '3.4'] }
 
     steps:
     - name: Checkout code

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rspec
 
@@ -8,7 +8,8 @@ inherit_gem:
     - rspec.yml
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
+  SuggestExtensions: false
   Exclude:
     - 'tmp/**/*'
     - 'examples/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'byebug'
+gem 'debug'
 gem 'lp'
 gem 'pretty_trace'
 gem 'rspec'

--- a/colorly.gemspec
+++ b/colorly.gemspec
@@ -13,16 +13,23 @@ Gem::Specification.new do |s|
   s.executables = ['colorly']
   s.homepage    = 'https://github.com/dannyben/colorly'
   s.license     = 'MIT'
-  s.required_ruby_version = '>= 3.1'
+  s.required_ruby_version = '>= 3.2'
 
-  s.add_runtime_dependency 'chroma', '~> 0.2'
-  s.add_runtime_dependency 'colsole', '~> 1.0'
-  s.add_runtime_dependency 'filewatcher', '~> 2.0'
-  s.add_runtime_dependency 'mister_bin', '~> 0.7'
-  s.add_runtime_dependency 'requires', '~> 1.0'
+  s.add_dependency 'chroma', '~> 0.2'
+  s.add_dependency 'colsole', '~> 1.0'
+  s.add_dependency 'filewatcher', '~> 2.0'
+  s.add_dependency 'mister_bin', '~> 0.7'
+  s.add_dependency 'ostruct', '~> 0.6'
+  s.add_dependency 'requires', '~> 1.0'
+
+  # FIXME: Remove when resolved.
+  #        This is a sub-dependency of filewatcher which does not bundle logger.
+  #        ref: https://github.com/filewatcher/filewatcher/pull/272
+  s.add_dependency 'logger', '~> 1.6'
 
   s.metadata = {
     'bug_tracker_uri'       => 'https://github.com/DannyBen/colorly/issues',
+    'changelog_uri'         => 'https://github.com/DannyBen/colorly/blob/master/CHANGELOG.md',
     'source_code_uri'       => 'https://github.com/dannyben/colorly',
     'rubygems_mfa_required' => 'true',
   }

--- a/lib/colorly.rb
+++ b/lib/colorly.rb
@@ -1,6 +1,5 @@
 require 'yaml'
 require 'requires'
-require 'byebug' if ENV['BYEBUG']
 
 requires 'colorly/exceptions'
 requires 'colorly/version'

--- a/lib/colorly/command.rb
+++ b/lib/colorly/command.rb
@@ -9,6 +9,7 @@ require 'yaml'
 module Colorly
   class Command < MisterBin::Command
     include Colsole
+
     summary 'Run a colorly script'
     version Colorly::VERSION
 

--- a/lib/colorly/script.rb
+++ b/lib/colorly/script.rb
@@ -1,6 +1,7 @@
 module Colorly
   class Script
     include DSL
+
     using StringRefinements
     attr_reader :script, :filename
     attr_writer :params

--- a/spec/approvals/script/error
+++ b/spec/approvals/script/error
@@ -1,1 +1,1 @@
-#<Colorly::ScriptError: spec/fixtures/broken_script.rb:3: undefined method `no_such_method' for an instance of Colorly::Script>
+#<Colorly::ScriptError: spec/fixtures/broken_script.rb:3: undefined method 'no_such_method' for an instance of Colorly::Script>

--- a/spec/colorly/script_spec.rb
+++ b/spec/colorly/script_spec.rb
@@ -37,7 +37,7 @@ describe Script do
       subject.run
       output = subject.output
 
-      expect(output.to_s).to eq '{"Hello"=>[red, cyan]}'
+      expect(output['Hello'].map(&:to_s)).to match_array(%w[red cyan])
       expect(output['Hello'].first).to be_a Chroma::Color
     end
 


### PR DESCRIPTION
- Add `logger` dependency due to https://github.com/filewatcher/filewatcher/pull/272
- Drop support for Ruby 3.1
- Add tests for Ruby 3.4
- Remove `byebug` dependency
- Update one failing test